### PR TITLE
Add option to disable writing min/max statistics for byte array

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,17 +19,17 @@ const (
 )
 
 const (
-	DefaultColumnIndexSizeLimit            = 16
-	DefaultColumnBufferCapacity            = 16 * 1024
-	DefaultPageBufferSize                  = 256 * 1024
-	DefaultWriteBufferSize                 = 32 * 1024
-	DefaultDataPageVersion                 = 2
-	DefaultDataPageStatistics              = false
-	DefaultEnableByteArrayMinMaxStatistics = false
-	DefaultSkipPageIndex                   = false
-	DefaultSkipBloomFilters                = false
-	DefaultMaxRowsPerRowGroup              = math.MaxInt64
-	DefaultReadMode                        = ReadModeSync
+	DefaultColumnIndexSizeLimit             = 16
+	DefaultColumnBufferCapacity             = 16 * 1024
+	DefaultPageBufferSize                   = 256 * 1024
+	DefaultWriteBufferSize                  = 32 * 1024
+	DefaultDataPageVersion                  = 2
+	DefaultDataPageStatistics               = false
+	DefaultDisableByteArrayMinMaxStatistics = false
+	DefaultSkipPageIndex                    = false
+	DefaultSkipBloomFilters                 = false
+	DefaultMaxRowsPerRowGroup               = math.MaxInt64
+	DefaultReadMode                         = ReadModeSync
 )
 
 const (
@@ -201,37 +201,37 @@ func (c *ReaderConfig) Validate() error {
 //		CreatedBy: "my test program",
 //	})
 type WriterConfig struct {
-	CreatedBy                       string
-	ColumnPageBuffers               BufferPool
-	ColumnIndexSizeLimit            int
-	PageBufferSize                  int
-	PageBufferSizes                 []int
-	WriteBufferSize                 int
-	DataPageVersion                 int
-	DataPageStatistics              bool
-	EnableByteArrayMinMaxStatistics bool
-	MaxRowsPerRowGroup              int64
-	DirectByteArrayWrites           bool
-	KeyValueMetadata                map[string]string
-	Schema                          *Schema
-	BloomFilters                    []BloomFilterColumn
-	Compression                     compress.Codec
-	Sorting                         SortingConfig
+	CreatedBy                        string
+	ColumnPageBuffers                BufferPool
+	ColumnIndexSizeLimit             int
+	PageBufferSize                   int
+	PageBufferSizes                  []int
+	WriteBufferSize                  int
+	DataPageVersion                  int
+	DataPageStatistics               bool
+	DisableByteArrayMinMaxStatistics bool
+	MaxRowsPerRowGroup               int64
+	DirectByteArrayWrites            bool
+	KeyValueMetadata                 map[string]string
+	Schema                           *Schema
+	BloomFilters                     []BloomFilterColumn
+	Compression                      compress.Codec
+	Sorting                          SortingConfig
 }
 
 // DefaultWriterConfig returns a new WriterConfig value initialized with the
 // default writer configuration.
 func DefaultWriterConfig() *WriterConfig {
 	return &WriterConfig{
-		CreatedBy:                       defaultCreatedBy(),
-		ColumnPageBuffers:               &defaultColumnBufferPool,
-		ColumnIndexSizeLimit:            DefaultColumnIndexSizeLimit,
-		PageBufferSize:                  DefaultPageBufferSize,
-		WriteBufferSize:                 DefaultWriteBufferSize,
-		DataPageVersion:                 DefaultDataPageVersion,
-		DataPageStatistics:              DefaultDataPageStatistics,
-		EnableByteArrayMinMaxStatistics: DefaultEnableByteArrayMinMaxStatistics,
-		MaxRowsPerRowGroup:              DefaultMaxRowsPerRowGroup,
+		CreatedBy:                        defaultCreatedBy(),
+		ColumnPageBuffers:                &defaultColumnBufferPool,
+		ColumnIndexSizeLimit:             DefaultColumnIndexSizeLimit,
+		PageBufferSize:                   DefaultPageBufferSize,
+		WriteBufferSize:                  DefaultWriteBufferSize,
+		DataPageVersion:                  DefaultDataPageVersion,
+		DataPageStatistics:               DefaultDataPageStatistics,
+		DisableByteArrayMinMaxStatistics: DefaultDisableByteArrayMinMaxStatistics,
+		MaxRowsPerRowGroup:               DefaultMaxRowsPerRowGroup,
 		Sorting: SortingConfig{
 			SortingBuffers: &defaultSortingBufferPool,
 		},
@@ -269,20 +269,20 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 	}
 
 	*config = WriterConfig{
-		CreatedBy:                       coalesceString(c.CreatedBy, config.CreatedBy),
-		ColumnPageBuffers:               coalesceBufferPool(c.ColumnPageBuffers, config.ColumnPageBuffers),
-		ColumnIndexSizeLimit:            coalesceInt(c.ColumnIndexSizeLimit, config.ColumnIndexSizeLimit),
-		PageBufferSize:                  coalesceInt(c.PageBufferSize, config.PageBufferSize),
-		WriteBufferSize:                 coalesceInt(c.WriteBufferSize, config.WriteBufferSize),
-		DataPageVersion:                 coalesceInt(c.DataPageVersion, config.DataPageVersion),
-		DataPageStatistics:              config.DataPageStatistics,
-		EnableByteArrayMinMaxStatistics: config.EnableByteArrayMinMaxStatistics,
-		MaxRowsPerRowGroup:              config.MaxRowsPerRowGroup,
-		KeyValueMetadata:                keyValueMetadata,
-		Schema:                          coalesceSchema(c.Schema, config.Schema),
-		BloomFilters:                    coalesceBloomFilters(c.BloomFilters, config.BloomFilters),
-		Compression:                     coalesceCompression(c.Compression, config.Compression),
-		Sorting:                         coalesceSortingConfig(c.Sorting, config.Sorting),
+		CreatedBy:                        coalesceString(c.CreatedBy, config.CreatedBy),
+		ColumnPageBuffers:                coalesceBufferPool(c.ColumnPageBuffers, config.ColumnPageBuffers),
+		ColumnIndexSizeLimit:             coalesceInt(c.ColumnIndexSizeLimit, config.ColumnIndexSizeLimit),
+		PageBufferSize:                   coalesceInt(c.PageBufferSize, config.PageBufferSize),
+		WriteBufferSize:                  coalesceInt(c.WriteBufferSize, config.WriteBufferSize),
+		DataPageVersion:                  coalesceInt(c.DataPageVersion, config.DataPageVersion),
+		DataPageStatistics:               config.DataPageStatistics,
+		DisableByteArrayMinMaxStatistics: config.DisableByteArrayMinMaxStatistics,
+		MaxRowsPerRowGroup:               config.MaxRowsPerRowGroup,
+		KeyValueMetadata:                 keyValueMetadata,
+		Schema:                           coalesceSchema(c.Schema, config.Schema),
+		BloomFilters:                     coalesceBloomFilters(c.BloomFilters, config.BloomFilters),
+		Compression:                      coalesceCompression(c.Compression, config.Compression),
+		Sorting:                          coalesceSortingConfig(c.Sorting, config.Sorting),
 	}
 }
 
@@ -585,14 +585,14 @@ func DataPageStatistics(enabled bool) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.DataPageStatistics = enabled })
 }
 
-// EnableByteArrayMinMaxStatistics creates a configuration option which defines whether
+// DisableByteArrayMinMaxStatistics creates a configuration option which defines whether
 // the min and max statistics for byte array type is recorded. Byte array usually records
 // raw data and sotring the min and max statistics will create a large overhead in the
 // metadata.
 //
-// Defaults to false.
-func EnableByteArrayMinMaxStatistics(enabled bool) WriterOption {
-	return writerOption(func(config *WriterConfig) { config.EnableByteArrayMinMaxStatistics = enabled })
+// Defaults to false so writing the byte array min and max statistics is enabled.
+func DIsableByteArrayMinMaxStatistics(enabled bool) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.DisableByteArrayMinMaxStatistics = enabled })
 }
 
 // KeyValueMetadata creates a configuration option which adds key/value metadata

--- a/config.go
+++ b/config.go
@@ -19,16 +19,17 @@ const (
 )
 
 const (
-	DefaultColumnIndexSizeLimit = 16
-	DefaultColumnBufferCapacity = 16 * 1024
-	DefaultPageBufferSize       = 256 * 1024
-	DefaultWriteBufferSize      = 32 * 1024
-	DefaultDataPageVersion      = 2
-	DefaultDataPageStatistics   = false
-	DefaultSkipPageIndex        = false
-	DefaultSkipBloomFilters     = false
-	DefaultMaxRowsPerRowGroup   = math.MaxInt64
-	DefaultReadMode             = ReadModeSync
+	DefaultColumnIndexSizeLimit            = 16
+	DefaultColumnBufferCapacity            = 16 * 1024
+	DefaultPageBufferSize                  = 256 * 1024
+	DefaultWriteBufferSize                 = 32 * 1024
+	DefaultDataPageVersion                 = 2
+	DefaultDataPageStatistics              = false
+	DefaultEnableByteArrayMinMaxStatistics = false
+	DefaultSkipPageIndex                   = false
+	DefaultSkipBloomFilters                = false
+	DefaultMaxRowsPerRowGroup              = math.MaxInt64
+	DefaultReadMode                        = ReadModeSync
 )
 
 const (
@@ -200,35 +201,37 @@ func (c *ReaderConfig) Validate() error {
 //		CreatedBy: "my test program",
 //	})
 type WriterConfig struct {
-	CreatedBy            string
-	ColumnPageBuffers    BufferPool
-	ColumnIndexSizeLimit int
-	PageBufferSize       int
-	PageBufferSizes      []int
-	WriteBufferSize      int
-	DataPageVersion      int
-	DataPageStatistics   bool
-	MaxRowsPerRowGroup   int64
-	DirectByteArrayWrites bool
-	KeyValueMetadata     map[string]string
-	Schema               *Schema
-	BloomFilters         []BloomFilterColumn
-	Compression          compress.Codec
-	Sorting              SortingConfig
+	CreatedBy                       string
+	ColumnPageBuffers               BufferPool
+	ColumnIndexSizeLimit            int
+	PageBufferSize                  int
+	PageBufferSizes                 []int
+	WriteBufferSize                 int
+	DataPageVersion                 int
+	DataPageStatistics              bool
+	EnableByteArrayMinMaxStatistics bool
+	MaxRowsPerRowGroup              int64
+	DirectByteArrayWrites           bool
+	KeyValueMetadata                map[string]string
+	Schema                          *Schema
+	BloomFilters                    []BloomFilterColumn
+	Compression                     compress.Codec
+	Sorting                         SortingConfig
 }
 
 // DefaultWriterConfig returns a new WriterConfig value initialized with the
 // default writer configuration.
 func DefaultWriterConfig() *WriterConfig {
 	return &WriterConfig{
-		CreatedBy:            defaultCreatedBy(),
-		ColumnPageBuffers:    &defaultColumnBufferPool,
-		ColumnIndexSizeLimit: DefaultColumnIndexSizeLimit,
-		PageBufferSize:       DefaultPageBufferSize,
-		WriteBufferSize:      DefaultWriteBufferSize,
-		DataPageVersion:      DefaultDataPageVersion,
-		DataPageStatistics:   DefaultDataPageStatistics,
-		MaxRowsPerRowGroup:   DefaultMaxRowsPerRowGroup,
+		CreatedBy:                       defaultCreatedBy(),
+		ColumnPageBuffers:               &defaultColumnBufferPool,
+		ColumnIndexSizeLimit:            DefaultColumnIndexSizeLimit,
+		PageBufferSize:                  DefaultPageBufferSize,
+		WriteBufferSize:                 DefaultWriteBufferSize,
+		DataPageVersion:                 DefaultDataPageVersion,
+		DataPageStatistics:              DefaultDataPageStatistics,
+		EnableByteArrayMinMaxStatistics: DefaultEnableByteArrayMinMaxStatistics,
+		MaxRowsPerRowGroup:              DefaultMaxRowsPerRowGroup,
 		Sorting: SortingConfig{
 			SortingBuffers: &defaultSortingBufferPool,
 		},
@@ -266,19 +269,20 @@ func (c *WriterConfig) ConfigureWriter(config *WriterConfig) {
 	}
 
 	*config = WriterConfig{
-		CreatedBy:            coalesceString(c.CreatedBy, config.CreatedBy),
-		ColumnPageBuffers:    coalesceBufferPool(c.ColumnPageBuffers, config.ColumnPageBuffers),
-		ColumnIndexSizeLimit: coalesceInt(c.ColumnIndexSizeLimit, config.ColumnIndexSizeLimit),
-		PageBufferSize:       coalesceInt(c.PageBufferSize, config.PageBufferSize),
-		WriteBufferSize:      coalesceInt(c.WriteBufferSize, config.WriteBufferSize),
-		DataPageVersion:      coalesceInt(c.DataPageVersion, config.DataPageVersion),
-		DataPageStatistics:   config.DataPageStatistics,
-		MaxRowsPerRowGroup:   config.MaxRowsPerRowGroup,
-		KeyValueMetadata:     keyValueMetadata,
-		Schema:               coalesceSchema(c.Schema, config.Schema),
-		BloomFilters:         coalesceBloomFilters(c.BloomFilters, config.BloomFilters),
-		Compression:          coalesceCompression(c.Compression, config.Compression),
-		Sorting:              coalesceSortingConfig(c.Sorting, config.Sorting),
+		CreatedBy:                       coalesceString(c.CreatedBy, config.CreatedBy),
+		ColumnPageBuffers:               coalesceBufferPool(c.ColumnPageBuffers, config.ColumnPageBuffers),
+		ColumnIndexSizeLimit:            coalesceInt(c.ColumnIndexSizeLimit, config.ColumnIndexSizeLimit),
+		PageBufferSize:                  coalesceInt(c.PageBufferSize, config.PageBufferSize),
+		WriteBufferSize:                 coalesceInt(c.WriteBufferSize, config.WriteBufferSize),
+		DataPageVersion:                 coalesceInt(c.DataPageVersion, config.DataPageVersion),
+		DataPageStatistics:              config.DataPageStatistics,
+		EnableByteArrayMinMaxStatistics: config.EnableByteArrayMinMaxStatistics,
+		MaxRowsPerRowGroup:              config.MaxRowsPerRowGroup,
+		KeyValueMetadata:                keyValueMetadata,
+		Schema:                          coalesceSchema(c.Schema, config.Schema),
+		BloomFilters:                    coalesceBloomFilters(c.BloomFilters, config.BloomFilters),
+		Compression:                     coalesceCompression(c.Compression, config.Compression),
+		Sorting:                         coalesceSortingConfig(c.Sorting, config.Sorting),
 	}
 }
 
@@ -579,6 +583,16 @@ func DataPageVersion(version int) WriterOption {
 // Defaults to false.
 func DataPageStatistics(enabled bool) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.DataPageStatistics = enabled })
+}
+
+// EnableByteArrayMinMaxStatistics creates a configuration option which defines whether
+// the min and max statistics for byte array type is recorded. Byte array usually records
+// raw data and sotring the min and max statistics will create a large overhead in the
+// metadata.
+//
+// Defaults to false.
+func EnableByteArrayMinMaxStatistics(enabled bool) WriterOption {
+	return writerOption(func(config *WriterConfig) { config.EnableByteArrayMinMaxStatistics = enabled })
 }
 
 // KeyValueMetadata creates a configuration option which adds key/value metadata

--- a/config.go
+++ b/config.go
@@ -591,7 +591,7 @@ func DataPageStatistics(enabled bool) WriterOption {
 // metadata.
 //
 // Defaults to false so writing the byte array min and max statistics is enabled.
-func DIsableByteArrayMinMaxStatistics(enabled bool) WriterOption {
+func DisableByteArrayMinMaxStatistics(enabled bool) WriterOption {
 	return writerOption(func(config *WriterConfig) { config.DisableByteArrayMinMaxStatistics = enabled })
 }
 

--- a/writer.go
+++ b/writer.go
@@ -600,7 +600,7 @@ func newWriterRowGroup(config *WriterConfig) *writerRowGroup {
 			bufferIndex:        int32(leaf.columnIndex),
 			bufferSize:         int32(float64(pbs) * 0.98),
 			writePageStats:     config.DataPageStatistics,
-			writeMinMaxStats:   columnType != ByteArrayType || config.EnableByteArrayMinMaxStatistics,
+			writeMinMaxStats:   columnType != ByteArrayType || (columnType == ByteArrayType && !config.DisableByteArrayMinMaxStatistics),
 			encodings:          make([]format.Encoding, 0, 3),
 			// Data pages in version 2 can omit compression when dictionary
 			// encoding is employed; only the dictionary page needs to be

--- a/writer.go
+++ b/writer.go
@@ -600,6 +600,7 @@ func newWriterRowGroup(config *WriterConfig) *writerRowGroup {
 			bufferIndex:        int32(leaf.columnIndex),
 			bufferSize:         int32(float64(pbs) * 0.98),
 			writePageStats:     config.DataPageStatistics,
+			writeMinMaxStats:   columnType != ByteArrayType || config.EnableByteArrayMinMaxStatistics,
 			encodings:          make([]format.Encoding, 0, 3),
 			// Data pages in version 2 can omit compression when dictionary
 			// encoding is employed; only the dictionary page needs to be
@@ -1263,13 +1264,14 @@ type writerColumn struct {
 		encoder  thrift.Encoder
 	}
 
-	filter         []byte
-	numRows        int64
-	bufferIndex    int32
-	bufferSize     int32
-	writePageStats bool
-	isCompressed   bool
-	encodings      []format.Encoding
+	filter           []byte
+	numRows          int64
+	bufferIndex      int32
+	bufferSize       int32
+	writePageStats   bool
+	writeMinMaxStats bool
+	isCompressed     bool
+	encodings        []format.Encoding
 
 	columnChunk *format.ColumnChunk
 	offsetIndex *format.OffsetIndex
@@ -1681,9 +1683,15 @@ func (c *writerColumn) writePageTo(size int64, writeTo func(io.Writer) (int64, e
 
 func (c *writerColumn) makePageStatistics(page Page) format.Statistics {
 	numNulls := page.NumNulls()
-	minValue, maxValue, _ := page.Bounds()
-	minValueBytes := minValue.Bytes()
-	maxValueBytes := maxValue.Bytes()
+
+	var minValueBytes, maxValueBytes []byte
+
+	if c.writeMinMaxStats {
+		minValue, maxValue, _ := page.Bounds()
+		minValueBytes = minValue.Bytes()
+		maxValueBytes = maxValue.Bytes()
+	}
+
 	return format.Statistics{
 		Min:       minValueBytes, // deprecated
 		Max:       maxValueBytes, // deprecated
@@ -1700,7 +1708,12 @@ func (c *writerColumn) recordPageStats(headerSize int32, header *format.PageHead
 	if page != nil {
 		numNulls := page.NumNulls()
 		numValues := page.NumValues()
-		minValue, maxValue, pageHasBounds := page.Bounds()
+
+		var minValue, maxValue Value
+		var pageHasBounds bool
+		if c.writeMinMaxStats {
+			minValue, maxValue, pageHasBounds = page.Bounds()
+		}
 		c.columnIndex.IndexPage(numValues, numNulls, minValue, maxValue)
 		c.columnChunk.MetaData.NumValues += numValues
 		c.columnChunk.MetaData.Statistics.NullCount += numNulls

--- a/writer_test.go
+++ b/writer_test.go
@@ -1262,7 +1262,7 @@ func TestByteArrayStatistics(t *testing.T) {
 		buffer,
 		schema,
 		parquet.DataPageStatistics(true),
-		parquet.DIsableByteArrayMinMaxStatistics(true),
+		parquet.DisableByteArrayMinMaxStatistics(true),
 	)
 
 	expectedMinTs := uint64(12345)


### PR DESCRIPTION
Adds an option to disable writing min/max statistics for byte arrays.

Usually, byte arrays are representation of raw data that does not need statistics of min and max value. Storing such value in the parquet file will create unnecessary overhead and could result in large memory consumption.